### PR TITLE
[GitHub] Classify template issues by issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,8 @@
 name: 🐛 Bug report
 description: Report errors or unexpected behavior
+type: Bug 🐛
 labels:
-  - bug 🐛
-  - unverified ⌛
+  - needs triage 🔍
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -2,7 +2,6 @@ name: 📃 Documentation Issue
 description: Report issues in our documentation
 labels:
   - documentation 📃
-  - unverified ⌛
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,8 @@
 name: 💡 Feature or enhancement request
 description: Propose something new
+type: Feature 📬
 labels:
-  - feature request 📬
-  - improvements ✨
-  - unverified ⌛
+  - needs triage 🔍
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** Issue templates classify a new issue by label, while the organization now provides issue types.

**Description:**

`bug_report.yml` sets `type: Bug 🐛` and `feature_request.yml` sets `type: Feature 📬`, matching the templates in `LookupEngine` and `LookupEngine.UI`.
The `bug 🐛`, `feature request 📬`, and `improvements ✨` labels leave the templates; the type carries the classification.
Every template now applies `needs triage 🔍` on arrival in place of `unverified ⌛`, which named the same state under an older name.
`documentation-issue.yml` keeps `documentation 📃` and takes no type.

The 62 existing issues that carried these labels already have the matching type set.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings