### PR TITLE
[GitHub] Point issue template links at this repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ labels:
 body:
   - type: markdown
     attributes:
-      value: Please make sure to [search for existing issues](https://github.com/jeremytammik/RevitLookup/issues?q=) before filing a new one!
+      value: Please make sure to [search for existing issues](https://github.com/lookup-foundation/RevitLookup/issues?q=) before filing a new one!
   - type: input
     attributes:
       label: RevitLookup version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📃 RevitLookup user documentation
-    url: https://github.com/jeremytammik/RevitLookup/wiki
+    url: https://github.com/lookup-foundation/RevitLookup/wiki
     about: Documentation for users of RevitLookup tool.
   - name: 📃 RevitLookup dev documentation
-    url: https://github.com/jeremytammik/RevitLookup/blob/dev/CONTRIBUTING.md
+    url: https://github.com/lookup-foundation/RevitLookup/blob/develop/CONTRIBUTING.md
     about: Documentation for people interested in developing and contributing for RevitLookup.


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** The issue templates link to `jeremytammik/RevitLookup`, the upstream this repository was forked from.

**Description:**

The duplicate-search link in `bug_report.yml` now queries the issues of this repository, so a reporter searches the tracker the issue lands in.
Both contact links in `config.yml` point here as well, and the contributing link follows `develop` in place of the retired `dev` branch.

The attribution table in `CONTRIBUTING.md` and the entries in `CHANGELOG.md` keep their upstream links; both record history.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings